### PR TITLE
Move baseimage from Node.js 10 to mainline (Node.js 12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM pelias/baseimage:nodejs-10
+FROM pelias/baseimage
 
 # libpostal apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers


### PR DESCRIPTION
The libpostal baseimage has historically stayed on the Node.js 10 branch of the Pelias base image due to incompatibility between [node-postal and Node.js 12](https://github.com/openvenues/node-postal/issues/24).

We are now using a Node.js 12 compatible fork of the `node-postal` library, so we can now bring the libpostal baseimage back to parity with the other Docker images.

This will reduce complexity, maintenance times, and download sizes for Pelias containers.

Connects https://github.com/pelias/interpolation/pull/245
Connects https://github.com/pelias/pelias/issues/800