### PR TITLE
Use multistage build to leave out libpostal buildtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-# base image
-FROM pelias/baseimage
+# builder image
+FROM pelias/baseimage as builder
 
 # libpostal apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
 RUN apt-get update && \
-    apt-get install -y autoconf automake libtool pkg-config python && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y autoconf automake libtool pkg-config python
 
 # clone libpostal
 RUN git clone https://github.com/openvenues/libpostal /code/libpostal
@@ -13,6 +12,12 @@ WORKDIR /code/libpostal
 
 # install libpostal
 RUN ./bootstrap.sh && \
-    ./configure --datadir=/usr/share/libpostal && \
+    ./configure --datadir=/usr/share/libpostal --prefix=/libpostal && \
     make && make check && make install && \
     ldconfig
+
+# main image
+FROM pelias/baseimage
+
+COPY --from=builder /usr/share/libpostal /usr/share/libpostal
+copy --from=builder /libpostal /


### PR DESCRIPTION
With https://github.com/pelias/docker-baseimage/pull/23 removing the C++ compiler toolchain from our baseimages, ideally we will remove build time dependencies everywhere to save space on disk and over the network.

The libpostal baseimage does require a compiler toolchain to build libpostal, but not to run it. So we can use a multistage image where libpostal is compiled with all its dependencies, but only the build artifacts are kept in the final image.

That saves a few hundred MB, but the libpostal GitHub repository is also about 80MB, so we get even more savings there.