### PR TITLE
Fix path when copying libpostal files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN ./bootstrap.sh && \
 FROM pelias/baseimage
 
 COPY --from=builder /usr/share/libpostal /usr/share/libpostal
-copy --from=builder /libpostal /
+COPY --from=builder /libpostal /usr/local


### PR DESCRIPTION
I didn't quite get this right the first time in https://github.com/pelias/docker-libpostal_baseimage/pull/5. The default location where libpostal files would be installed into is `/usr/local`.