### PR TITLE
Fix usage of `DESTDIR` and `--prefix`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ WORKDIR /code/libpostal
 
 # install libpostal
 RUN ./bootstrap.sh && \
-    ./configure --datadir=/usr/share/libpostal --prefix=/libpostal && \
-    make && make check && make install && \
+    ./configure --datadir=/usr/share/libpostal && \
+    make && make check && DESTDIR=/libpostal make install && \
     ldconfig
 
 # main image
 FROM pelias/baseimage
 
 COPY --from=builder /usr/share/libpostal /usr/share/libpostal
-COPY --from=builder /libpostal /usr/local
+COPY --from=builder /libpostal /


### PR DESCRIPTION
One last (hopefully) fix to get everything working. (My Makefile skills are a little rusty).

Instead of using the `--prefix` option to `./configure` (which tells `./configure` the final location that the package will actually be installed into), use `PREFIX` when calling make install. This basically translates all the directories without changing anything else.

This is what we want, since the idea is to create a directory with just libpostal files that can be cleanly copied from the builder image to the final image.