### PR TITLE
Pin to version of libpostal that builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ RUN apt-get update && \
     apt-get install -y autoconf automake libtool pkg-config python
 
 # clone libpostal
-RUN git clone https://github.com/openvenues/libpostal /code/libpostal
+RUN git clone https://github.com/openvenues/libpostal /code/libpostal && \
+# pin to libpostal version not affected by https://github.com/openvenues/libpostal/issues/592
+  cd /code/libpostal && git checkout a97717f2b9f8fba03d25442f2bd88c15e86ec81b
+
 WORKDIR /code/libpostal
 
 # install libpostal


### PR DESCRIPTION
This repository has not actually been able to build a Docker image in a while, because of a build issue with libpostal. Until that build issue can be resolved,we pin to a commit that builds.

https://github.com/openvenues/libpostal/issues/592