### PR TITLE
Update `apt` package names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM pelias/baseimage as builder
 # libpostal apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
 RUN apt-get update && \
-    apt-get install -y autoconf automake libtool pkg-config python
+    apt-get install -y build-essential autoconf automake libtool pkg-config python
 
 # clone libpostal
 RUN git clone https://github.com/openvenues/libpostal /code/libpostal && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM pelias/baseimage as builder
 # libpostal apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
 RUN apt-get update && \
-    apt-get install -y build-essential autoconf automake libtool pkg-config python
+    apt-get install -y build-essential autoconf automake libtool pkg-config python3
 
 # clone libpostal
 RUN git clone https://github.com/openvenues/libpostal /code/libpostal && \


### PR DESCRIPTION
In preparation for moving our Docker base images to [Ubuntu 22](https://github.com/pelias/pelias/issues/951), we need to make a few minor changes to the `apt` packages we install in this repo.

Two simple changes included here:
- Add `build-essential`. For whatever reason this is now required to get `make`. We install it in a builder image which is discarded so we don't have to worry about additional space in the final image
- Move from `python` to `python3`. The `python` package is going away, and we want Python 3 for building things.