### PR TITLE
Revert "Pin to version of libpostal that builds"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ RUN apt-get update && \
     apt-get install -y build-essential autoconf automake libtool pkg-config python3
 
 # clone libpostal
-RUN git clone https://github.com/openvenues/libpostal /code/libpostal && \
-# pin to libpostal version not affected by https://github.com/openvenues/libpostal/issues/592
-  cd /code/libpostal && git checkout a97717f2b9f8fba03d25442f2bd88c15e86ec81b
-
+RUN git clone https://github.com/openvenues/libpostal /code/libpostal
 WORKDIR /code/libpostal
 
 # install libpostal


### PR DESCRIPTION
This PR reverts commit 5f89119a11fbcce5df475eba9a3f337181d2d8ad since the issue has been resolved in https://github.com/openvenues/libpostal/pull/632

ref: https://github.com/pelias/docker-libpostal_baseimage/pull/10